### PR TITLE
Revamp home page with profile selection and recent items design

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../models/app_state.dart';
+import '../models/comparison_record.dart';
 import 'profile_form_page.dart';
 import 'item_form_page.dart';
 import 'comparison_page.dart';
@@ -13,75 +14,167 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final state = context.watch<AppState>();
+    final selected = state.selectedProfile;
     return Scaffold(
+      backgroundColor: Colors.pink.shade50,
       appBar: AppBar(
-        title: const Text('Pitta'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.history),
-            onPressed: () => Navigator.push(
-              context,
-              MaterialPageRoute(builder: (_) => const HistoryPage()),
-            ),
-          )
-        ],
+        title: const Text(
+          'Pitta',
+          style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
+        ),
+        centerTitle: true,
+        backgroundColor: Colors.pink.shade300,
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => _showAddMenu(context),
-        child: const Icon(Icons.add),
-      ),
-      body: ListView(
-        children: [
-          if (state.selectedProfile != null)
-            ListTile(
-              title: Text('Profile: ${state.selectedProfile!.name}'),
-              onTap: () => _selectProfile(context),
-            ),
-          ...state.history.take(5).map(
-                (r) => ListTile(
-                  title: Text(r.item.name),
-                  subtitle: Text(r.comments().join(', ')),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => ComparisonPage(record: r),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Colors.pink.shade300,
+                borderRadius: const BorderRadius.only(
+                  bottomLeft: Radius.circular(30),
+                  bottomRight: Radius.circular(30),
+                ),
+              ),
+              child: Column(
+                children: [
+                  const Text(
+                    'だれの服をチェックする？',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
                     ),
                   ),
-                ),
-              )
-        ],
-      ),
-    );
-  }
-
-  void _showAddMenu(BuildContext context) {
-    showModalBottomSheet(
-      context: context,
-      builder: (_) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              leading: const Icon(Icons.person),
-              title: const Text('Add Body Profile'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const ProfileFormPage()),
-                );
-              },
+                  const SizedBox(height: 15),
+                  if (state.profiles.isEmpty)
+                    const Text(
+                      'まずは体型を登録してください',
+                      style: TextStyle(color: Colors.white70),
+                    )
+                  else
+                    Wrap(
+                      spacing: 10,
+                      children: state.profiles
+                          .map(
+                            (p) => GestureDetector(
+                              onTap: () => state.selectProfile(p),
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 20, vertical: 10),
+                                decoration: BoxDecoration(
+                                  color: selected == p
+                                      ? Colors.white
+                                      : Colors.pink.shade200,
+                                  borderRadius: BorderRadius.circular(20),
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Icon(
+                                      Icons.person,
+                                      color: selected == p
+                                          ? Colors.pink.shade300
+                                          : Colors.white,
+                                      size: 18,
+                                    ),
+                                    const SizedBox(width: 5),
+                                    Text(
+                                      p.name,
+                                      style: TextStyle(
+                                        color: selected == p
+                                            ? Colors.pink.shade300
+                                            : Colors.white,
+                                        fontWeight: FontWeight.w600,
+                                        fontSize: 14,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          )
+                          .toList(),
+                    ),
+                ],
+              ),
             ),
-            ListTile(
-              leading: const Icon(Icons.checkroom),
-              title: const Text('Add Clothing Size'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const ItemFormPage()),
-                );
-              },
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: _buildActionButton(
+                            context,
+                            icon: Icons.person_add,
+                            title: '体型登録',
+                            subtitle: 'サイズを登録',
+                            color: Colors.blue.shade300,
+                            onTap: () => Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (_) => const ProfileFormPage()),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 15),
+                        Expanded(
+                          child: _buildActionButton(
+                            context,
+                            icon: Icons.checkroom,
+                            title: '服サイズ入力',
+                            subtitle: '服のサイズを入力',
+                            color: Colors.orange.shade300,
+                            onTap: selected == null
+                                ? null
+                                : () => Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                          builder: (_) => const ItemFormPage()),
+                                    ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 30),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          '最近チェックした服',
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.grey.shade700,
+                          ),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: (_) => const HistoryPage()),
+                          ),
+                          child: const Text('すべて見る'),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    Expanded(
+                      child: ListView.builder(
+                        itemCount: state.history.length,
+                        itemBuilder: (context, index) =>
+                            _buildClothingItemCard(context, state.history[index]),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ),
           ],
         ),
@@ -89,32 +182,184 @@ class HomePage extends StatelessWidget {
     );
   }
 
-  void _selectProfile(BuildContext context) {
-    final state = context.read<AppState>();
-    showDialog(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Select Profile'),
-        content: SizedBox(
-          width: double.maxFinite,
-          child: ListView(
-            shrinkWrap: true,
-            children: state.profiles
-                .map(
-                  (p) => RadioListTile(
-                    value: p,
-                    groupValue: state.selectedProfile,
-                    onChanged: (v) {
-                      state.selectProfile(p);
-                      Navigator.pop(ctx);
-                    },
-                    title: Text(p.name),
-                  ),
-                )
-                .toList(),
-          ),
+  Widget _buildActionButton(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required Color color,
+    required VoidCallback? onTap,
+  }) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: 120,
+        padding: const EdgeInsets.all(15),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(15),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.grey.shade300,
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: color.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Icon(
+                icon,
+                color: color,
+                size: 28,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              title,
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 14,
+                color: Colors.grey.shade800,
+              ),
+            ),
+            Text(
+              subtitle,
+              style: TextStyle(
+                fontSize: 11,
+                color: Colors.grey.shade600,
+              ),
+            ),
+          ],
         ),
       ),
     );
   }
+
+  Widget _buildClothingItemCard(
+      BuildContext context, ComparisonRecord record) {
+    final item = record.item;
+    final status = _fitStatus(record);
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(15),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.shade200,
+            blurRadius: 6,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 50,
+            height: 50,
+            decoration: BoxDecoration(
+              color: Colors.pink.shade100,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(
+              Icons.checkroom,
+              color: Colors.grey.shade600,
+              size: 24,
+            ),
+          ),
+          const SizedBox(width: 15),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item.name,
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 16,
+                    color: Colors.grey.shade800,
+                  ),
+                ),
+                if (item.brand != null) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    item.brand!,
+                    style: TextStyle(
+                      color: Colors.grey.shade600,
+                      fontSize: 13,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 8, vertical: 3),
+                      decoration: BoxDecoration(
+                        color: _fitStatusColor(status).withOpacity(0.1),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        status,
+                        style: TextStyle(
+                          color: _fitStatusColor(status),
+                          fontSize: 11,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => ComparisonPage(record: record),
+              ),
+            ),
+            icon: Icon(Icons.refresh, color: Colors.grey.shade600),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _fitStatus(ComparisonRecord record) {
+    final diffs = [
+      record.shoulderDiff,
+      record.bodyDiff,
+      record.lengthDiff,
+      record.sleeveDiff,
+    ];
+    if (diffs.every((d) => d.abs() < 1)) return 'ちょうどいい';
+    if (diffs.any((d) > 0)) return '少し大きめ';
+    return '少し小さめ';
+  }
+
+  Color _fitStatusColor(String status) {
+    switch (status) {
+      case 'ちょうどいい':
+        return Colors.green;
+      case '少し大きめ':
+        return Colors.orange;
+      case '少し小さめ':
+        return Colors.red;
+      default:
+        return Colors.grey;
+    }
+  }
 }
+


### PR DESCRIPTION
## Summary
- Add styled profile selection header matching app theme
- Provide action buttons for adding body profiles and clothing items
- Display recent comparison records with fit status indicators

## Testing
- `dart format lib/screens/home_page.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee5891d408332803b260ba4c51551