### PR TITLE
feat: restyle profile form

### DIFF
--- a/lib/screens/profile_form_page.dart
+++ b/lib/screens/profile_form_page.dart
@@ -34,54 +34,110 @@ class _ProfileFormPageState extends State<ProfileFormPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Body Profile')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: ListView(
-            children: [
-              TextFormField(
-                controller: _nameController,
-                decoration: const InputDecoration(labelText: 'Name'),
-                validator: (v) => v!.isEmpty ? 'Required' : null,
-              ),
-              _numberField(_heightController, 'Height (cm)'),
-              _numberField(_shoulderController, 'Shoulder width (cm)'),
-              _numberField(_chestController, 'Chest (cm)'),
-              _numberField(_waistController, 'Waist (cm)'),
-              _numberField(_hipController, 'Hip (cm)'),
-              const SizedBox(height: 24),
-              ElevatedButton(
-                onPressed: () {
-                  if (_formKey.currentState!.validate()) {
-                    final profile = BodyProfile(
-                      name: _nameController.text,
-                      height: double.parse(_heightController.text),
-                      shoulderWidth: double.parse(_shoulderController.text),
-                      chest: double.parse(_chestController.text),
-                      waist: double.parse(_waistController.text),
-                      hip: double.parse(_hipController.text),
-                    );
-                    context.read<AppState>().addProfile(profile);
-                    Navigator.pop(context);
-                  }
-                },
-                child: const Text('Save'),
-              )
-            ],
+      backgroundColor: Colors.pink.shade50,
+      appBar: AppBar(
+        title: const Text(
+          '体型登録',
+          style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
+        ),
+        centerTitle: true,
+        backgroundColor: Colors.pink.shade300,
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(20),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              children: [
+                _buildTextField(_nameController, label: '名前'),
+                const SizedBox(height: 16),
+                _buildNumberField(_heightController, label: '身長 (cm)'),
+                const SizedBox(height: 16),
+                _buildNumberField(_shoulderController, label: '肩幅 (cm)'),
+                const SizedBox(height: 16),
+                _buildNumberField(_chestController, label: '胸囲 (cm)'),
+                const SizedBox(height: 16),
+                _buildNumberField(_waistController, label: 'ウエスト (cm)'),
+                const SizedBox(height: 16),
+                _buildNumberField(_hipController, label: 'ヒップ (cm)'),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.pink.shade300,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    onPressed: () {
+                      if (_formKey.currentState!.validate()) {
+                        final profile = BodyProfile(
+                          name: _nameController.text,
+                          height: double.parse(_heightController.text),
+                          shoulderWidth: double.parse(_shoulderController.text),
+                          chest: double.parse(_chestController.text),
+                          waist: double.parse(_waistController.text),
+                          hip: double.parse(_hipController.text),
+                        );
+                        context.read<AppState>().addProfile(profile);
+                        Navigator.pop(context);
+                      }
+                    },
+                    child: const Text(
+                      '登録する',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),
     );
   }
 
-  Widget _numberField(TextEditingController controller, String label) {
+  Widget _buildTextField(TextEditingController controller, {required String label}) {
     return TextFormField(
       controller: controller,
-      decoration: InputDecoration(labelText: label),
+      decoration: _inputDecoration(label),
+      validator: (v) => v!.isEmpty ? '必須項目です' : null,
+    );
+  }
+
+  Widget _buildNumberField(TextEditingController controller, {required String label}) {
+    return TextFormField(
+      controller: controller,
+      decoration: _inputDecoration(label),
       keyboardType: TextInputType.number,
-      validator: (v) => v!.isEmpty ? 'Required' : null,
+      validator: (v) => v!.isEmpty ? '必須項目です' : null,
+    );
+  }
+
+  InputDecoration _inputDecoration(String label) {
+    return InputDecoration(
+      labelText: label,
+      filled: true,
+      fillColor: Colors.white,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: Colors.grey.shade300),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: Colors.grey.shade300),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: Colors.pink.shade300),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- restyle profile registration form to match app design
- add Japanese labels and themed button

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bee74cf2988332a11d173b1040e743