### PR TITLE
Add favorites and tabbed history view

### DIFF
--- a/lib/models/app_state.dart
+++ b/lib/models/app_state.dart
@@ -26,4 +26,17 @@ class AppState extends ChangeNotifier {
     history.insert(0, ComparisonRecord(profile: profile, item: item));
     notifyListeners();
   }
+
+  void removeComparison(ComparisonRecord record) {
+    history.remove(record);
+    notifyListeners();
+  }
+
+  void toggleFavorite(ComparisonRecord record) {
+    record.isFavorite = !record.isFavorite;
+    notifyListeners();
+  }
+
+  List<ComparisonRecord> get favorites =>
+      history.where((r) => r.isFavorite).toList();
 }

--- a/lib/models/comparison_record.dart
+++ b/lib/models/comparison_record.dart
@@ -5,11 +5,14 @@ class ComparisonRecord {
   ComparisonRecord({
     required this.profile,
     required this.item,
+    DateTime? compareDate,
+    this.isFavorite = false,
   }) {
     shoulderDiff = item.shoulderWidth - profile.shoulderWidth;
     bodyDiff = item.bodyWidth - profile.chest;
     lengthDiff = item.length - profile.height * 0.38; // naive torso length
     sleeveDiff = item.sleeveLength - profile.height * 0.25;
+    this.compareDate = compareDate ?? DateTime.now();
   }
 
   final BodyProfile profile;
@@ -18,6 +21,9 @@ class ComparisonRecord {
   late final double bodyDiff;
   late final double lengthDiff;
   late final double sleeveDiff;
+
+  bool isFavorite;
+  late final DateTime compareDate;
 
   String commentFor(double diff, String part) {
     if (diff.abs() < 1) return '$part is just right';
@@ -31,4 +37,19 @@ class ComparisonRecord {
         commentFor(lengthDiff, 'Length'),
         commentFor(sleeveDiff, 'Sleeve'),
       ];
+
+  Map<String, double> sizeDiffs() => {
+        '肩幅': shoulderDiff,
+        '身幅': bodyDiff,
+        '着丈': lengthDiff,
+        '袖丈': sleeveDiff,
+      };
+
+  String overallFit() {
+    final diffs = [shoulderDiff, bodyDiff, lengthDiff, sleeveDiff];
+    final maxAbs = diffs.map((d) => d.abs()).reduce((a, b) => a > b ? a : b);
+    final avg = diffs.reduce((a, b) => a + b) / diffs.length;
+    if (maxAbs < 1) return 'ちょうど良い';
+    return avg > 0 ? '少し大きめ' : '小さすぎ';
+  }
 }

--- a/lib/screens/history_page.dart
+++ b/lib/screens/history_page.dart
@@ -2,32 +2,391 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../models/app_state.dart';
+import '../models/comparison_record.dart';
 import 'comparison_page.dart';
 
-class HistoryPage extends StatelessWidget {
+class HistoryPage extends StatefulWidget {
   const HistoryPage({super.key});
+
+  @override
+  State<HistoryPage> createState() => _HistoryPageState();
+}
+
+class _HistoryPageState extends State<HistoryPage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  String _formatDate(DateTime date) {
+    final now = DateTime.now();
+    final difference = now.difference(date).inDays;
+    if (difference == 0) {
+      return '今日';
+    } else if (difference == 1) {
+      return '昨日';
+    } else if (difference < 7) {
+      return '${difference}日前';
+    } else {
+      return '${difference ~/ 7}週間前';
+    }
+  }
+
+  Color _fitColor(String fit) {
+    switch (fit) {
+      case 'ちょうど良い':
+        return Colors.green;
+      case '少し大きめ':
+        return Colors.orange;
+      default:
+        return Colors.red;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final state = context.watch<AppState>();
+    final history = state.history;
+    final favorites = state.favorites;
+
     return Scaffold(
-      appBar: AppBar(title: const Text('History')),
-      body: ListView.builder(
-        itemCount: state.history.length,
-        itemBuilder: (context, index) {
-          final record = state.history[index];
-          return ListTile(
-            title: Text(record.item.name),
-            subtitle: Text(record.comments().join(', ')),
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => ComparisonPage(record: record),
+      backgroundColor: Colors.pink[50],
+      appBar: AppBar(
+        backgroundColor: Colors.pink[100],
+        elevation: 0,
+        title: const Text(
+          '履歴・お気に入り',
+          style: TextStyle(
+            color: Colors.black87,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black87),
+          onPressed: () => Navigator.pop(context),
+        ),
+        bottom: TabBar(
+          controller: _tabController,
+          indicatorColor: Colors.pink[400],
+          labelColor: Colors.pink[600],
+          unselectedLabelColor: Colors.grey[600],
+          labelStyle: const TextStyle(fontWeight: FontWeight.bold),
+          tabs: [
+            Tab(
+              icon: const Icon(Icons.history),
+              text: '履歴 (${history.length})',
+            ),
+            Tab(
+              icon: const Icon(Icons.favorite),
+              text: 'お気に入り (${favorites.length})',
+            ),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          _buildItemList(history, state, true),
+          _buildItemList(favorites, state, false),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildItemList(
+    List<ComparisonRecord> items,
+    AppState state,
+    bool isHistoryTab,
+  ) {
+    if (items.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              isHistoryTab ? Icons.history : Icons.favorite_border,
+              size: 80,
+              color: Colors.grey[300],
+            ),
+            const SizedBox(height: 16),
+            Text(
+              isHistoryTab ? 'まだ比較履歴がありません' : 'お気に入りがありません',
+              style: TextStyle(
+                fontSize: 16,
+                color: Colors.grey[500],
+                fontWeight: FontWeight.w500,
               ),
             ),
-          );
-        },
+            const SizedBox(height: 8),
+            Text(
+              isHistoryTab ? '服のサイズを比較してみましょう！' : 'お気に入りの服を見つけましょう！',
+              style: TextStyle(
+                fontSize: 14,
+                color: Colors.grey[400],
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: items.length,
+      itemBuilder: (context, index) {
+        final item = items[index];
+        return _buildComparisonCard(item, state, isHistoryTab);
+      },
+    );
+  }
+
+  Widget _buildComparisonCard(
+    ComparisonRecord record,
+    AppState state,
+    bool isHistoryTab,
+  ) {
+    final overallFit = record.overallFit();
+    final fitColor = _fitColor(overallFit);
+    final sizes = record.sizeDiffs();
+
+    return Card(
+      elevation: 2,
+      margin: const EdgeInsets.only(bottom: 12),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(15),
+      ),
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(15),
+          gradient: LinearGradient(
+            colors: [Colors.white, Colors.pink[25] ?? Colors.white],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              Row(
+                children: [
+                  Container(
+                    width: 50,
+                    height: 50,
+                    decoration: BoxDecoration(
+                      color: Colors.pink[100],
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Icon(
+                      Icons.checkroom,
+                      color: Colors.pink[400],
+                      size: 25,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          record.item.name,
+                          style: const TextStyle(
+                            fontSize: 15,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        if (record.item.brand != null)
+                          Text(
+                            record.item.brand!,
+                            style: TextStyle(
+                              fontSize: 13,
+                              color: Colors.grey[600],
+                            ),
+                          ),
+                        Row(
+                          children: [
+                            if (isHistoryTab) ...[
+                              const Spacer(),
+                              Text(
+                                _formatDate(record.compareDate),
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: Colors.grey[500],
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  Column(
+                    children: [
+                      IconButton(
+                        onPressed: () => state.toggleFavorite(record),
+                        icon: Icon(
+                          record.isFavorite
+                              ? Icons.favorite
+                              : Icons.favorite_border,
+                          color: record.isFavorite
+                              ? Colors.red[400]
+                              : Colors.grey[400],
+                        ),
+                      ),
+                      if (isHistoryTab)
+                        IconButton(
+                          onPressed: () => state.removeComparison(record),
+                          icon: Icon(
+                            Icons.delete_outline,
+                            color: Colors.grey[400],
+                            size: 20,
+                          ),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: fitColor.withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: fitColor.withOpacity(0.3),
+                    width: 1,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                        color: fitColor,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      '総合評価: $overallFit',
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const Spacer(),
+                    Icon(
+                      overallFit == 'ちょうど良い'
+                          ? Icons.check_circle_outline
+                          : overallFit == '少し大きめ'
+                              ? Icons.expand_more
+                              : Icons.warning_outline,
+                      color: fitColor,
+                      size: 18,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: sizes.entries.map((entry) {
+                  final value = entry.value;
+                  Color sizeColor;
+                  if (value.abs() <= 1) {
+                    sizeColor = Colors.green;
+                  } else if (value.abs() <= 3) {
+                    sizeColor = Colors.orange;
+                  } else {
+                    sizeColor = Colors.red;
+                  }
+                  return Column(
+                    children: [
+                      Text(
+                        entry.key,
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: Colors.grey[600],
+                        ),
+                      ),
+                      Text(
+                        '${value > 0 ? '+' : ''}${value.toStringAsFixed(1)}',
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                          color: sizeColor,
+                        ),
+                      ),
+                    ],
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => ComparisonPage(record: record),
+                        ),
+                      ),
+                      icon: const Icon(Icons.visibility),
+                      label: const Text('詳細を見る'),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.pink[600],
+                        side: BorderSide(color: Colors.pink[300] ?? Colors.pink),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: () {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: const Text('再比較を開始します'),
+                            backgroundColor: Colors.blue[400],
+                            behavior: SnackBarBehavior.floating,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                          ),
+                        );
+                      },
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('再比較'),
+                      style: ElevatedButton.styleFrom(
+                        foregroundColor: Colors.white,
+                        backgroundColor: Colors.pink[400],
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }
 }
+


### PR DESCRIPTION
## Summary
- Expand comparison records with favorite flag, compare date and helpers
- Provide state methods to manage favorites and history removal
- Redesign history page with tabs for history and favorites and detailed comparison cards

## Testing
- ⚠️ `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beedc4acf883328d11b2dd7b92ebc0