### PR TITLE
Fix predicate typo in fit status calculation

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -345,7 +345,7 @@ class HomePage extends StatelessWidget {
       record.sleeveDiff,
     ];
     if (diffs.every((d) => d.abs() < 1)) return 'ちょうどいい';
-    if (diffs.any((d) > 0)) return '少し大きめ';
+    if (diffs.any((d) => d > 0)) return '少し大きめ';
     return '少し小さめ';
   }
 


### PR DESCRIPTION
## Summary
- fix invalid `any` predicate in HomePage's fit status helper

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bef3a381c88332b473c33a8207fc46