### PR TITLE
Use Noto Sans JP font

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 import 'models/app_state.dart';
 import 'screens/home_page.dart';
@@ -17,7 +18,10 @@ class PittaApp extends StatelessWidget {
       create: (_) => AppState(),
       child: MaterialApp(
         title: 'Pitta',
-        theme: ThemeData(useMaterial3: true),
+        theme: ThemeData(
+          useMaterial3: true,
+          textTheme: GoogleFonts.notoSansJpTextTheme(),
+        ),
         home: const HomePage(),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   provider: ^6.1.2
+  google_fonts: ^6.1.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add google_fonts dependency for Noto Sans JP
- apply Noto Sans JP text theme to MaterialApp

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8dda18f8833298981899cfa8c5e4