### PR TITLE
style: apply new color scheme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,12 +18,76 @@ class PittaApp extends StatelessWidget {
       create: (_) => AppState(),
       child: MaterialApp(
         title: 'Pitta',
-        theme: ThemeData(
-          useMaterial3: true,
-          textTheme: GoogleFonts.notoSansJpTextTheme(),
-        ),
+        theme: _buildTheme(),
         home: const HomePage(),
       ),
     );
   }
+}
+
+ThemeData _buildTheme() {
+  final baseText = GoogleFonts.notoSansJpTextTheme()
+      .apply(bodyColor: const Color(0xFF1F2937), displayColor: const Color(0xFF1F2937));
+  final body = const Color(0xFF1F2937);
+  final support = const Color(0xFF6B7280);
+  // Gradient for optional use with primary color styling.
+  // ignore: unused_local_variable
+  const primaryGradient = LinearGradient(
+    colors: [Color(0xFF26D0CE), Color(0xFF1AA2B5)],
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+  );
+
+  return ThemeData(
+    useMaterial3: true,
+    scaffoldBackgroundColor: const Color(0xFFEAF2F1),
+    colorScheme: const ColorScheme(
+      brightness: Brightness.light,
+      primary: Color(0xFF25C5C1),
+      onPrimary: Colors.white,
+      secondary: Color(0xFFF8C24E),
+      onSecondary: Colors.white,
+      error: Color(0xFFFF6B6B),
+      onError: Colors.white,
+      background: Color(0xFFEAF2F1),
+      onBackground: Color(0xFF1F2937),
+      surface: Colors.white,
+      onSurface: Color(0xFF1F2937),
+      tertiary: Color(0xFF22C55E),
+    ),
+    cardTheme: CardTheme(
+      color: Colors.white,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(24),
+      ),
+      elevation: 4,
+      shadowColor: Colors.black.withOpacity(0.08),
+    ),
+    textTheme: baseText.copyWith(
+      headlineLarge: baseText.headlineLarge?.copyWith(
+        color: body,
+        height: 1.25,
+      ),
+      headlineMedium: baseText.headlineMedium?.copyWith(
+        color: body,
+        height: 1.25,
+      ),
+      headlineSmall: baseText.headlineSmall?.copyWith(
+        color: body,
+        height: 1.25,
+      ),
+      bodyLarge: baseText.bodyLarge?.copyWith(
+        color: body,
+        height: 1.5,
+      ),
+      bodyMedium: baseText.bodyMedium?.copyWith(
+        color: body,
+        height: 1.5,
+      ),
+      bodySmall: baseText.bodySmall?.copyWith(
+        color: support,
+        height: 1.5,
+      ),
+    ),
+  );
 }


### PR DESCRIPTION
## Summary
- introduce unified theme builder
- apply mint primary palette and neumorphic card styling
- set typography colors and line heights for headings and body text

## Testing
- `dart format lib/main.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf93cfa16c8332b64dddd0914913be