### PR TITLE
Align drop position with tap X coordinate

### DIFF
--- a/lib/game/fruit_game.dart
+++ b/lib/game/fruit_game.dart
@@ -163,6 +163,7 @@ class FruitGame extends Forge2DGame with TapCallbacks {
   @override
   void onTapUp(TapUpEvent event) {
     if (isGameOver || !canDrop || nextFruit == null) return;
+    _updateDropPosition(event.canvasPosition.x);
     _dropFruit();
   }
   


### PR DESCRIPTION
### Motivation
- Fix an issue where spawned fruits repeatedly fell toward the left side because the drop X position was not being updated from the tap location.

### Description
- Update `onTapUp` to call `_updateDropPosition(event.canvasPosition.x)` before spawning the fruit so the drop uses the tap's canvas X coordinate.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968b4cc475083329487862a2af514ae)